### PR TITLE
Initialize the ContactSelectionListFragment from the SelectedRecipientsAdapter, tackles #47

### DIFF
--- a/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
+++ b/src/org/thoughtcrime/securesms/ContactSelectionListFragment.java
@@ -61,6 +61,7 @@ import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -83,6 +84,7 @@ public class ContactSelectionListFragment extends    Fragment
   public static final String RECENTS               = "recents";
   public static final String SELECT_VERIFIED_EXTRA = "select_verified";
   public static final String FROM_SHARE_ACTIVITY_EXTRA = "from_share_activity";
+  public static final String PRESELECTED_CONTACTS = "preselected_contacts";
 
   private ApplicationDcContext dcContext;
 
@@ -243,6 +245,10 @@ public class ContactSelectionListFragment extends    Fragment
             isMulti(),
             true);
     selectedContacts = adapter.getSelectedContacts();
+    ArrayList<String> preselectedContacts = getActivity().getIntent().getStringArrayListExtra(PRESELECTED_CONTACTS);
+    if(preselectedContacts!=null) {
+      selectedContacts.addAll(preselectedContacts);
+    }
     recyclerView.setAdapter(adapter);
     recyclerView.addItemDecoration(new StickyHeaderDecoration(adapter, true, true));
   }

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -423,17 +423,14 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     public void onClick(View v) {
       Intent intent = new Intent(GroupCreateActivity.this, ContactMultiSelectionActivity.class);
       intent.putExtra(ContactSelectionListFragment.SELECT_VERIFIED_EXTRA, verified);
-      if(editGroupChatId!=null) {
-        Recipient recipient = GroupCreateActivity.this.dcContext.getRecipient(ApplicationDcContext.RECIPIENT_TYPE_CHAT, editGroupChatId);
-        List<Recipient> participants = recipient.getParticipants();
-        ArrayList<String> preselectedContacts = new ArrayList<>();
-        for (Recipient p : participants) {
-          if(p.getAddress().isDcContact()) {
-            preselectedContacts.add(dcContext.getContact(p.getAddress().getDcContactId()).getAddr());
-          }
+      ArrayList<String> preselectedContacts = new ArrayList<>();
+      Set<Recipient> recipients = GroupCreateActivity.this.getAdapter().getRecipients();
+      for (Recipient r : recipients) {
+        if(r.getAddress().isDcContact()) {
+          preselectedContacts.add(dcContext.getContact(r.getAddress().getDcContactId()).getAddr());
         }
-        intent.putExtra(ContactSelectionListFragment.PRESELECTED_CONTACTS, preselectedContacts);
       }
+      intent.putExtra(ContactSelectionListFragment.PRESELECTED_CONTACTS, preselectedContacts);
       startActivityForResult(intent, PICK_CONTACT);
     }
   }

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -62,6 +62,7 @@ import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 import org.thoughtcrime.securesms.util.guava.Optional;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -151,6 +152,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void addSelectedContacts(@NonNull Recipient... recipients) {
+    getAdapter().clear();
     new AddMembersTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, recipients);
   }
 
@@ -421,6 +423,17 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     public void onClick(View v) {
       Intent intent = new Intent(GroupCreateActivity.this, ContactMultiSelectionActivity.class);
       intent.putExtra(ContactSelectionListFragment.SELECT_VERIFIED_EXTRA, verified);
+      if(editGroupChatId!=null) {
+        Recipient recipient = GroupCreateActivity.this.dcContext.getRecipient(ApplicationDcContext.RECIPIENT_TYPE_CHAT, editGroupChatId);
+        List<Recipient> participants = recipient.getParticipants();
+        ArrayList<String> preselectedContacts = new ArrayList<>();
+        for (Recipient p : participants) {
+          if(p.getAddress().isDcContact()) {
+            preselectedContacts.add(dcContext.getContact(p.getAddress().getDcContactId()).getAddr());
+          }
+        }
+        intent.putExtra(ContactSelectionListFragment.PRESELECTED_CONTACTS, preselectedContacts);
+      }
       startActivityForResult(intent, PICK_CONTACT);
     }
   }

--- a/src/org/thoughtcrime/securesms/util/SelectedRecipientsAdapter.java
+++ b/src/org/thoughtcrime/securesms/util/SelectedRecipientsAdapter.java
@@ -67,6 +67,11 @@ public class SelectedRecipientsAdapter extends BaseAdapter {
     }
   }
 
+  public void clear() {
+    recipients.clear();
+    notifyDataSetChanged();
+  }
+
   public Set<Recipient> getRecipients() {
     final Set<Recipient> recipientSet = new HashSet<>(recipients.size());
     for (RecipientWrapper wrapper : recipients) {


### PR DESCRIPTION
When adding more groupmembers from the GroupCreateActivity, the contacts which are already included in the group are preselected in the ContactSelectionListFragment.

Further more, if the user then deselect one of this preselected contacts, it is also removed from the GroupCreateActivity.