### PR TITLE
remove multidex

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,6 @@ dependencies {
     compile 'com.android.support:preference-v7:27.0.2'
     compile 'com.android.support:preference-v14:27.0.2'
     compile 'com.android.support:gridlayout-v7:27.0.2'
-    compile 'com.android.support:multidex:1.0.2'
     compile 'com.android.support:exifinterface:27.0.2'
     compile 'com.android.support.constraint:constraint-layout:1.1.2'
     compile 'android.arch.lifecycle:extensions:1.1.1'
@@ -113,10 +112,6 @@ dependencies {
     testCompile 'org.powermock:powermock-module-junit4-rule:1.6.1'
     testCompile 'org.powermock:powermock-classloading-xstream:1.6.1'
 
-    androidTestCompile 'com.android.support:multidex:1.0.2'
-    androidTestCompile 'com.android.support:multidex-instrumentation:1.0.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
     androidTestCompile ('org.assertj:assertj-core:1.7.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
@@ -136,7 +131,6 @@ dependencyVerification {
         'com.android.support:support-v13:6f2848811ceef2e32cc98da02a045d65f7e7447a6bd7198b9ec10aa14d7ad55c',
         'com.android.support:cardview-v7:57f867a3c8f33e2d4dc0a03e2dfa03cad6267a908179f04a725a68ea9f0b8ccf',
         'com.android.support:gridlayout-v7:227b5fdffa20f53bd562503aab6d2293d52cf64b5a6ab1116d2150f87bff9e88',
-        'com.android.support:multidex:7cd48755c7cfdb6dd2d21cbb02236ec390f6ac91cde87eb62f475b259ab5301d',
         'com.android.support:exifinterface:0e7cd526c4468895cd8549def46b3d33c8bcfb1ae4830569898d8c7326b15bb2',
         'android.arch.lifecycle:extensions:429426b2feec2245ffc5e75b3b5309bedb36159cf06dc71843ae43526ac289b6',
         'android.arch.lifecycle:common-java8:7078b5c8ccb94203df9cc2a463c69cf0021596e6cf966d78fbfd697aaafe0630',
@@ -193,10 +187,6 @@ android {
     buildToolsVersion '27.0.1'
     useLibrary 'org.apache.http.legacy'
 
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
-
     defaultConfig {
         versionCode 409
         versionName "0.97.2"
@@ -204,7 +194,6 @@ android {
 
         minSdkVersion 14
         targetSdkVersion 25
-        multiDexEnabled true
 
         vectorDrawables.useSupportLibrary = true
         project.ext.set("archivesBaseName", "Deltachat");

--- a/src/org/thoughtcrime/securesms/ApplicationContext.java
+++ b/src/org/thoughtcrime/securesms/ApplicationContext.java
@@ -17,12 +17,12 @@
 package org.thoughtcrime.securesms;
 
 import android.annotation.SuppressLint;
+import android.app.Application;
 import android.arch.lifecycle.DefaultLifecycleObserver;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.ProcessLifecycleOwner;
 import android.content.Context;
 import android.support.annotation.NonNull;
-import android.support.multidex.MultiDexApplication;
 
 import com.b44t.messenger.DcContext;
 import com.b44t.messenger.DcEventCenter;
@@ -45,7 +45,7 @@ import org.thoughtcrime.securesms.util.AndroidSignalProtocolLogger;
  *
  * @author Moxie Marlinspike
  */
-public class ApplicationContext extends MultiDexApplication implements DefaultLifecycleObserver {
+public class ApplicationContext extends Application implements DefaultLifecycleObserver {
 
   private static final String TAG = ApplicationContext.class.getName();
 


### PR DESCRIPTION
multidex is required when using more than 64K methods.

however, it has some disadvantages eg. in file size, startup time and memory usage, esp on older devices. http://blog.safedk.com/technology/two-years-multidex-65k-limit/

as we simply do no longer need multidex, we should just disable it.

