### PR TITLE
show date beside time

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -605,9 +605,9 @@ public class ConversationFragment extends Fragment
         ViewUtil.animateIn(scrollToBottomButton, scrollButtonInAnimation);
       }
 
-      if (positionId != lastPositionId) {
-        bindScrollHeader(conversationDateHeader, positionId);
-      }
+//      if (positionId != lastPositionId) {
+//        bindScrollHeader(conversationDateHeader, positionId);
+//      }
 
       wasAtBottom           = currentlyAtBottom;
       wasAtZoomScrollHeight = currentlyAtZoomScrollHeight;
@@ -618,11 +618,11 @@ public class ConversationFragment extends Fragment
 
     @Override
     public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
-      if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
-        conversationDateHeader.show();
-      } else if (newState == RecyclerView.SCROLL_STATE_IDLE) {
-        conversationDateHeader.hide();
-      }
+//      if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+//        conversationDateHeader.show();
+//      } else if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+//        conversationDateHeader.hide();
+//      }
     }
 
     private boolean isAtBottom() {

--- a/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
+++ b/src/org/thoughtcrime/securesms/components/ConversationItemFooter.java
@@ -71,12 +71,12 @@ public class ConversationItemFooter extends LinearLayout {
 
   private void presentDate(@NonNull DcMsg messageRecord, @NonNull Locale locale) {
     dateView.forceLayout();
-    if(messageRecord.hasDeviatingTimestamp()) {
+//    if(messageRecord.hasDeviatingTimestamp()) {
       dateView.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getTimestamp()));
-    }
-    else {
-      dateView.setText(DateUtils.getTimeOfDayTimeSpanString(getContext(), locale, messageRecord.getTimestamp()));
-    }
+//    }
+//    else {
+//      dateView.setText(DateUtils.getTimeOfDayTimeSpanString(getContext(), locale, messageRecord.getTimestamp()));
+//    }
   }
 
   private void presentSecureIndicator(@NonNull DcMsg messageRecord) {

--- a/src/org/thoughtcrime/securesms/util/DateUtils.java
+++ b/src/org/thoughtcrime/securesms/util/DateUtils.java
@@ -80,7 +80,8 @@ public class DateUtils extends android.text.format.DateUtils {
       return c.getResources().getQuantityString(R.plurals.n_minutes, mins, mins);
     } else {
       StringBuilder format = new StringBuilder();
-      if      (isWithin(timestamp,   6, TimeUnit.DAYS)) format.append("EEE ");
+      if      (DateUtils.isToday(timestamp))                 {}
+      else if (isWithin(timestamp,   6, TimeUnit.DAYS)) format.append("EEE ");
       else if (isWithin(timestamp, 365, TimeUnit.DAYS)) format.append("MMM d, ");
       else                                              format.append("MMM d, yyyy, ");
 
@@ -143,7 +144,7 @@ public class DateUtils extends android.text.format.DateUtils {
     } else if (isYesterday(timestamp)) {
       return context.getString(R.string.yesterday);
     } else {
-      return getFormattedDateTime(timestamp, "EEE, MMM d, yyyy", locale);
+      return getFormattedDateTime(timestamp, "EEEE, MMMM d, yyyy", locale);
     }
   }
 
@@ -156,10 +157,13 @@ public class DateUtils extends android.text.format.DateUtils {
   }
 
   private static String getLocalizedPattern(String template, Locale locale) {
+    String ret;
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-      return DateFormat.getBestDateTimePattern(locale, template);
+      ret = DateFormat.getBestDateTimePattern(locale, template);
     } else {
-      return new SimpleDateFormat(template, locale).toLocalizedPattern();
+      ret = new SimpleDateFormat(template, locale).toLocalizedPattern();
     }
+    ret.replace(".,", ",");
+    return ret;
   }
 }


### PR DESCRIPTION
this pr adds a _short-format-date_ beside the time of messages.

the date is only shown for post _not from today_ and makes the flickering appearing and disappearing header superfluous. also ux-wise this may be the better solution as the date is now always at the same position.

the larger date-headers should double information now, however, they will stay in place as they are also separating the list in an intuitive way. also, they always show all date details.

i think we should test this a bit, we can later decide to go back to the flickering date header, if really needed.