### PR TITLE
correct titles for 'OK' buttons

### DIFF
--- a/res/menu/chat_background.xml
+++ b/res/menu/chat_background.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:title="@string/ok"
+          android:id="@+id/apply_background"
+          android:icon="?menu_accept_icon"
+          app:showAsAction="always|withText"/>
+
+</menu>

--- a/res/menu/registration.xml
+++ b/res/menu/registration.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:title="@string/ok"
+          android:id="@+id/do_register"
+          android:icon="?menu_accept_icon"
+          app:showAsAction="always|withText"/>
+
+</menu>

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -78,8 +78,8 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuInflater inflater = this.getMenuInflater();
         menu.clear();
-        inflater.inflate(R.menu.group_create, menu);
-        loginMenuItem = menu.findItem(R.id.menu_create_group);
+        inflater.inflate(R.menu.registration, menu);
+        loginMenuItem = menu.findItem(R.id.do_register);
         super.onPrepareOptionsMenu(menu);
         return true;
     }
@@ -87,7 +87,7 @@ public class RegistrationActivity extends BaseActionBarActivity implements DcEve
     public boolean onOptionsItemSelected(MenuItem item) {
         int id = item.getItemId();
 
-        if (id == R.id.menu_create_group) {
+        if (id == R.id.do_register) {
             onLogin();
             return true;
         } else if (id == android.R.id.home) {

--- a/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
+++ b/src/org/thoughtcrime/securesms/preferences/ChatBackgroundActivity.java
@@ -74,8 +74,8 @@ public class ChatBackgroundActivity extends BaseActionBarActivity {
     public boolean onPrepareOptionsMenu(Menu menu) {
         MenuInflater inflater = this.getMenuInflater();
         menu.clear();
-        inflater.inflate(R.menu.group_create, menu);
-        acceptMenuItem = menu.findItem(R.id.menu_create_group);
+        inflater.inflate(R.menu.chat_background, menu);
+        acceptMenuItem = menu.findItem(R.id.apply_background);
         acceptMenuItem.setEnabled(false);
         super.onPrepareOptionsMenu(menu);
         return true;
@@ -85,7 +85,7 @@ public class ChatBackgroundActivity extends BaseActionBarActivity {
     public boolean onOptionsItemSelected(MenuItem item) {
         int id = item.getItemId();
 
-        if (id == R.id.menu_create_group) {
+        if (id == R.id.apply_background) {
             // handle confirmation button click here
             Context context = getApplicationContext();
             if(imageUri != null){


### PR DESCRIPTION
the 'OK' buttons on the background-selection and in the registration-activity had the labels and the internal id 'create group' (possibly by a copy+paste action).

the wrong wording is visible mainly in landscape mode, but maybe also on larger screens in portrait mode.

this pr creates separate menus for these activities and corrects the wording.